### PR TITLE
feat: nfc logo position depending model

### DIFF
--- a/switcloud-l2-demo/src/main/java/io/switstack/switcloud/switcloud_l2_demo/MainActivity.kt
+++ b/switcloud-l2-demo/src/main/java/io/switstack/switcloud/switcloud_l2_demo/MainActivity.kt
@@ -1,5 +1,6 @@
 package io.switstack.switcloud.switcloud_l2_demo
 
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -28,6 +29,10 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if(BuildConfig.DEBUG) {
+            println("${Build.BRAND} ${Build.PRODUCT}")
+            println("${Build.BRAND.uppercase()}_${Build.PRODUCT.uppercase()}")
+        }
         WindowCompat.setDecorFitsSystemWindows(window, false)
         paymentViewModel.setupSwitcloudL2(this)
         setContent {

--- a/switcloud-l2-demo/src/main/java/io/switstack/switcloud/switcloud_l2_demo/PaymentScreen.kt
+++ b/switcloud-l2-demo/src/main/java/io/switstack/switcloud/switcloud_l2_demo/PaymentScreen.kt
@@ -1,16 +1,19 @@
 package io.switstack.switcloud.switcloud_l2_demo
 
 import android.content.res.Configuration
+import android.os.Build
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Payment
@@ -18,6 +21,7 @@ import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -32,6 +36,7 @@ import androidx.compose.ui.tooling.preview.Devices.TABLET
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.switstack.switcloud.switcloud_l2_demo.data.NfcAntennaDeviceEnum
 import io.switstack.switcloud.switcloud_l2_demo.ui.PaymentViewModel
 import io.switstack.switcloud.switcloud_l2_demo.ui.theme.Switcloudl2demoktTheme
 import io.switstack.switcloud.switcloud_l2_demo.utils.AmountUtils
@@ -82,24 +87,32 @@ fun PaymentScreenContent(amount: String,
                          onBackToPreviousClick: () -> Unit,
                          onCancelClick: () -> Unit
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
-            .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Box(
-            modifier = Modifier
-                .width(300.dp)
-                .background(
-                    color = MaterialTheme.colorScheme.primary,
-                    shape = RoundedCornerShape(16.dp)
-                )
-                .padding(16.dp),
+    val modelEnum = try {
+        NfcAntennaDeviceEnum.valueOf("${Build.BRAND.uppercase()}_${Build.PRODUCT.uppercase()}")
+        //NfcAntennaDeviceEnum.INEFI_ANDROID_G17
+        //NfcAntennaDeviceEnum.PEPPERL_FUCHS_TABIND10AND
+    } catch (e: Exception) {
+        println(e)
+        null
+    }
+
+    Box(modifier = Modifier
+        .fillMaxSize()
+        .background(MaterialTheme.colorScheme.background)
+        .padding(16.dp),
+        contentAlignment = Alignment.Center) {
+
+        Box(modifier = Modifier
+            .width(300.dp)
+            .background(
+                color = MaterialTheme.colorScheme.primary,
+                shape = RoundedCornerShape(16.dp)
+            )
+            .align(Alignment.TopCenter),
             contentAlignment = Alignment.Center
         ) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Column(modifier = Modifier.padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally) {
                 Icon(
                     modifier = Modifier.size(60.dp),
                     imageVector = iconPayment,
@@ -115,67 +128,88 @@ fun PaymentScreenContent(amount: String,
             }
         }
 
-        Spacer(modifier = Modifier.weight(1f))
-
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
             when {
                 errorMessage != null -> {
-                    Image(
+                    Image(modifier = Modifier
+                        .width(100.dp)
+                        .align(Alignment.CenterHorizontally),
                         painter = painterResource(id = R.drawable.ic_crossmark),
                         contentDescription = "Error crossmark",
-                        modifier = Modifier.width(100.dp)
                     )
-                    Text(text = errorMessage,
-                         color = MaterialTheme.colorScheme.onBackground,
-                         style = MaterialTheme.typography.bodyLarge)
+                    Text(modifier = Modifier.align(Alignment.CenterHorizontally),
+                        text = errorMessage,
+                        color = MaterialTheme.colorScheme.onBackground,
+                        style = MaterialTheme.typography.bodyLarge)
                 }
 
                 success -> {
-                    Image(
+                    Image(modifier = Modifier
+                        .width(100.dp)
+                        .align(Alignment.CenterHorizontally),
                         painter = painterResource(id = R.drawable.ic_checkmark),
-                        contentDescription = "Success checkmark",
-                        modifier = Modifier.width(100.dp)
+                        contentDescription = "Success checkmark"
                     )
                 }
 
                 !ready -> {
-                    CircularProgressIndicator(modifier = Modifier.size(75.dp))
-                    Text(modifier = Modifier.padding(top = 32.dp),
-                         text = "Loading in progress...",
-                         color = MaterialTheme.colorScheme.onBackground,
-                         style = MaterialTheme.typography.titleLarge)
+                    CircularProgressIndicator(modifier = Modifier
+                        .size(75.dp)
+                        .align(Alignment.CenterHorizontally))
+                    Text(modifier = Modifier
+                        .padding(top = 32.dp)
+                        .align(Alignment.CenterHorizontally),
+                        text = "Loading in progress...",
+                        color = MaterialTheme.colorScheme.onBackground,
+                        style = MaterialTheme.typography.titleLarge)
                 }
 
                 ready -> {
-                    Image(
-                        painter = painterResource(id = R.drawable.ic_contactless),
-                        contentDescription = "EMVCo contactless logo",
-                        colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
-                        modifier = Modifier.width(150.dp)
-                    )
-                    Text(text = "Tap here to pay",
-                         color = MaterialTheme.colorScheme.onBackground,
-                         style = MaterialTheme.typography.titleLarge)
+                    modelEnum?.let { model ->
+                        Surface(modifier = Modifier
+                            .absoluteOffset(
+                                model.land_x_offset,
+                                model.land_y_offset)
+                            .widthIn(max = 400.dp),
+                            color = MaterialTheme.colorScheme.secondaryContainer,
+                            shadowElevation = 8.dp,
+                            shape = RoundedCornerShape(16.dp)
+                        ) {
+                            Image(
+                                modifier = Modifier
+                                    .padding(horizontal = 32.dp, vertical = 8.dp)
+                                    .width(150.dp),
+                                painter = painterResource(id = R.drawable.ic_contactless),
+                                contentDescription = "EMVCo contactless logo",
+                                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground)
+                            )
+                        }
+                    }
+                    Text(modifier = Modifier.padding(top = 8.dp),
+                        text = "Present card",
+                        color = MaterialTheme.colorScheme.onBackground,
+                        style = MaterialTheme.typography.titleLarge)
                 }
             }
         }
 
-        Spacer(modifier = Modifier.weight(1f))
-
-        errorMessage?.let {
-            Action(buttonText = stringResource(R.string.back_to_previous),
-                   buttonType = ButtonType.Filled,
-                   onClick = onBackToPreviousClick)
-        } ?: run {
-            if (ready && !success) {
-                Action(buttonText = "Cancel",
-                       buttonType = ButtonType.Tonal,
-                       onClick = onCancelClick)
+        Column(modifier = Modifier.align(Alignment.BottomCenter),
+            horizontalAlignment = Alignment.CenterHorizontally) {
+            errorMessage?.let {
+                Action(
+                    buttonText = stringResource(R.string.back_to_previous),
+                    buttonType = ButtonType.Filled,
+                    onClick = onBackToPreviousClick)
+            } ?: run {
+                if (ready && !success) {
+                    Action(
+                        buttonText = "Cancel",
+                        buttonType = ButtonType.Tonal,
+                        onClick = onCancelClick)
+                }
             }
+            Footer()
         }
-        Footer()
     }
 }
 
@@ -212,7 +246,6 @@ fun PaymentScreenReadyPreview() {
     }
 }
 
-
 @Preview(device = TABLET)
 @Preview(device = TABLET, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
@@ -227,7 +260,6 @@ fun PaymentScreenSuccessPreview() {
                              { })
     }
 }
-
 
 @Preview(device = TABLET)
 @Preview(device = TABLET, uiMode = Configuration.UI_MODE_NIGHT_YES)

--- a/switcloud-l2-demo/src/main/java/io/switstack/switcloud/switcloud_l2_demo/data/NfcAntennaDeviceEnum.kt
+++ b/switcloud-l2-demo/src/main/java/io/switstack/switcloud/switcloud_l2_demo/data/NfcAntennaDeviceEnum.kt
@@ -1,0 +1,10 @@
+package io.switstack.switcloud.switcloud_l2_demo.data
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+enum class NfcAntennaDeviceEnum(val land_x_offset: Dp, val land_y_offset: Dp, val port_x_offset: Dp, val port_y_offset: Dp) {
+    PEPPERL_FUCHS_TABIND10AND(0.dp, 0.dp, 0.dp, 0.dp), //OONA 10 Android
+    INEFI_ANDROID_G17( 450.dp, -100.dp, 0.dp, 0.dp), //FLYTECH POS317
+    SUNMI_D3_MINI( 0.dp, 0.dp, 0.dp, 0.dp)
+}


### PR DESCRIPTION
- Adding NfcAntennaDeviceEnum to manage different offsets of nfc antenna per device
- Adapting the NFC logo position on PaymentScreen
- Reordering PaymentScreen layout to keep the NFC logo into the exact center of the screen
- @Alex-Switstack : Check if the error and success logo is well positionned